### PR TITLE
feat: Update Django to ~5.0 and Python to 3.10

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,10 +9,10 @@ black = "*"
 
 [packages]
 Pillow = ">=7.1.0"
-Django = ">=1.11.29"
+Django = "~=5.0"
 
 [requires]
-python_version = "3.6"
+python_version = "3.10"
 
 [pipenv]
 allow_prereleases = true

--- a/pagina/settings.py
+++ b/pagina/settings.py
@@ -120,8 +120,9 @@ STATIC_URL = "/static/"
 
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static"),
-    "/static/css/",
 ]
 
 MEDIA_ROOT = os.path.join(BASE_DIR, "static/media")
 MEDIA_URL = "/static/media/"
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/pagina/tests.py
+++ b/pagina/tests.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from django.urls import resolve
-from django.core.urlresolvers import reverse
+from django.urls import resolve, reverse
 from django.test import TestCase
 from .views import home
 
@@ -11,9 +10,9 @@ class HomeTests(TestCase):
     def test_home_view_status_code(self):
         url = reverse("home")
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     # Testar se as definições de URL são corretas
     def test_home_url_resolves_home_view(self):
         view = resolve("/")
-        self.assertEquals(view.func, home)
+        self.assertEqual(view.func, home)

--- a/pagina/urls.py
+++ b/pagina/urls.py
@@ -1,19 +1,18 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 from django.conf.urls.static import static
 from pagina import settings
 from django.contrib import admin
-from django.views.static import serve
 
 from pagina import views
 
 urlpatterns = [
-    url(r"^$", views.home, name="home"),
-    url(r"^admin/", admin.site.urls),
-    url(r"^upload/", views.model_upload, name="model_upload"),
-    url(r"^edit/(?P<pk>\d+)", views.model_edit, name="model_edit"),
-    url(r"^delete/(?P<pk>\d+)", views.model_delete, name="model_delete"),
-    url(r"^add_favorites/(?P<pk>\d+)", views.add_favorites, name="add_favorites"),
-    url(r"^favoritos/", views.favoritos, name="favoritos"),
+    re_path(r"^$", views.home, name="home"),
+    path("admin/", admin.site.urls),
+    re_path(r"^upload/", views.model_upload, name="model_upload"),
+    re_path(r"^edit/(?P<pk>\d+)", views.model_edit, name="model_edit"),
+    re_path(r"^delete/(?P<pk>\d+)", views.model_delete, name="model_delete"),
+    re_path(r"^add_favorites/(?P<pk>\d+)", views.add_favorites, name="add_favorites"),
+    re_path(r"^favoritos/", views.favoritos, name="favoritos"),
 ]
 
 if settings.DEBUG:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django>=1.11.29
+Django~=5.0
 Pillow>=7.1.0


### PR DESCRIPTION
Updates the project to use Django  ~5.0 and Python version 3.10.

Key changes include:
- Updated `Pipfile` and `requirements.txt` with the new versions.
- Modified `pagina/urls.py` to use `path` and `re_path` instead of `url`.
- Added `DEFAULT_AUTO_FIELD` to `pagina/settings.py`.
- Ensured `manage.py check` runs without errors.
- Database migrations have been successfully applied.
- Existing automated tests pass with the new versions.